### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The @googleapis/yoshi-python is the default owner for changes in this repo
+*               @googleapis/api-bigquery @googleapis/yoshi-python
+
+# The python-samples-reviewers team is the default owner for samples changes
+/samples/  @googleapis/api-bigquery @googleapis/python-samples-owners


### PR DESCRIPTION
OSPO's security recommendations include requiring CODEOWNERS review.
