### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,7 @@
     "library_type": "INTEGRATION",
     "repo": "googleapis/python-bigquery-pandas",
     "distribution_name": "pandas-gbq",
-    "api_id": "bigquery.googleapis.com"
-  }
+    "api_id": "bigquery.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
+}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,5 +11,5 @@
     "distribution_name": "pandas-gbq",
     "api_id": "bigquery.googleapis.com",
     "default_version": "",
-    "codeowner_team": ""
+    "codeowner_team": "@googleapis/api-bigquery"
 }


### PR DESCRIPTION
This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114