### PR TITLE
fix: allow extreme DATE values such as `datetime.date(1, 1, 1)` in `load_gbq`

### DIFF
--- a/ci/requirements-3.7-0.24.2.conda
+++ b/ci/requirements-3.7-0.24.2.conda
@@ -1,10 +1,11 @@
 codecov
 coverage
-db-dtypes==0.3.0
+db-dtypes==0.3.1
 fastavro
 flake8
 numpy==1.16.6
-google-cloud-bigquery==1.11.1
+google-cloud-bigquery==1.26.1
+google-cloud-bigquery-storage==1.1.0
 pyarrow==3.0.0
 pydata-google-auth
 pytest

--- a/ci/requirements-3.7-0.24.2.conda
+++ b/ci/requirements-3.7-0.24.2.conda
@@ -4,8 +4,7 @@ db-dtypes==0.3.1
 fastavro
 flake8
 numpy==1.16.6
-google-cloud-bigquery==1.26.1
-google-cloud-bigquery-storage==1.1.0
+google-cloud-bigquery==1.11.1
 pyarrow==3.0.0
 pydata-google-auth
 pytest

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -94,8 +94,13 @@ def cast_dataframe_for_parquet(
             # .astype() with DateDtype. With .astype(), I get the error:
             #
             # TypeError: Cannot interpret '<db_dtypes.DateDtype ...>' as a data type
-            cast_column = pandas.Series(
-                dataframe[column_name], dtype=db_dtypes.DateDtype()
+            cast_column = dataframe[column_name].astype(
+                dtype=db_dtypes.DateDtype(),
+                # Return the original column if there was an error converting
+                # to the dtype, such as is there is a date outside the
+                # supported range.
+                # https://github.com/googleapis/python-bigquery-pandas/issues/441
+                errors="ignore",
             )
         elif column_type in {"NUMERIC", "DECIMAL", "BIGNUMERIC", "BIGDECIMAL"}:
             cast_column = dataframe[column_name].map(decimal.Decimal)

--- a/pandas_gbq/load.py
+++ b/pandas_gbq/load.py
@@ -90,10 +90,6 @@ def cast_dataframe_for_parquet(
             # Use extension dtype first so that it uses the correct equality operator.
             and db_dtypes.DateDtype() != dataframe[column_name].dtype
         ):
-            # Construct converted column manually, because I can't use
-            # .astype() with DateDtype. With .astype(), I get the error:
-            #
-            # TypeError: Cannot interpret '<db_dtypes.DateDtype ...>' as a data type
             cast_column = dataframe[column_name].astype(
                 dtype=db_dtypes.DateDtype(),
                 # Return the original column if there was an error converting

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ dependencies = [
     "google-auth-oauthlib",
     # 2.4.* has a bug where waiting for the query can hang indefinitely.
     # https://github.com/pydata/pandas-gbq/issues/343
-    "google-cloud-bigquery >=1.26.1,<3.0.0dev,!=2.4.*",
-    "google-cloud-bigquery-storage >=1.1.0,<3.0.0dev",
+    "google-cloud-bigquery[bqstorage,pandas] >=1.11.1,<3.0.0dev,!=2.4.*",
 ]
 extras = {
     "tqdm": "tqdm>=4.23.0",

--- a/setup.py
+++ b/setup.py
@@ -23,16 +23,17 @@ description = "Google BigQuery connector for pandas"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "setuptools",
-    "db-dtypes >=0.3.0,<2.0.0",
-    "numpy>=1.16.6",
-    "pandas>=0.24.2",
+    "db-dtypes >=0.3.1,<2.0.0",
+    "numpy >=1.16.6",
+    "pandas >=0.24.2",
     "pyarrow >=3.0.0, <7.0dev",
     "pydata-google-auth",
     "google-auth",
     "google-auth-oauthlib",
     # 2.4.* has a bug where waiting for the query can hang indefinitely.
     # https://github.com/pydata/pandas-gbq/issues/343
-    "google-cloud-bigquery[bqstorage,pandas]>=1.11.1,<3.0.0dev,!=2.4.*",
+    "google-cloud-bigquery >=1.26.1,<3.0.0dev,!=2.4.*",
+    "google-cloud-bigquery-storage >=1.1.0,<3.0.0dev",
 ]
 extras = {
     "tqdm": "tqdm>=4.23.0",

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,10 +5,10 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-db-dtypes==0.3.0
-google-auth==1.4.1
+db-dtypes==0.3.1
+google-auth==1.18.0
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==1.11.1
+google-cloud-bigquery==1.26.1
 google-cloud-bigquery-storage==1.1.0
 numpy==1.16.6
 pandas==0.24.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,9 +6,9 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 db-dtypes==0.3.1
-google-auth==1.18.0
+google-auth==1.4.1
 google-auth-oauthlib==0.0.1
-google-cloud-bigquery==1.26.1
+google-cloud-bigquery==1.11.1
 google-cloud-bigquery-storage==1.1.0
 numpy==1.16.6
 pandas==0.24.2

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -188,6 +188,54 @@ DATAFRAME_ROUND_TRIPS = [
             {"name": "num_col", "type": "NUMERIC"},
         ],
     ),
+    pytest.param(
+        *DataFrameRoundTripTestCase(
+            input_df=pandas.DataFrame(
+                {
+                    "row_num": [1, 2, 3],
+                    # DATE valuess outside the pandas range for timestamp
+                    # aren't supported by the db-dtypes package.
+                    # https://github.com/googleapis/python-bigquery-pandas/issues/441
+                    "date_col": [
+                        datetime.date(1, 1, 1),
+                        datetime.date(1970, 1, 1),
+                        datetime.date(9999, 12, 31),
+                    ],
+                    # DATETIME values outside of the range for pandas timestamp
+                    # require `date_as_object` parameter in
+                    # google-cloud-bigquery versions 1.x and 2.x.
+                    # https://github.com/googleapis/python-bigquery-pandas/issues/365
+                    "datetime_col": [
+                        datetime.datetime(1, 1, 1),
+                        datetime.datetime(1970, 1, 1),
+                        datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
+                    ],
+                    "timestamp_col": [
+                        datetime.datetime(1, 1, 1, tzinfo=datetime.timezone.utc),
+                        datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+                        datetime.datetime(
+                            9999,
+                            12,
+                            31,
+                            23,
+                            59,
+                            59,
+                            999999,
+                            tzinfo=datetime.timezone.utc,
+                        ),
+                    ],
+                },
+                columns=["row_num", "date_col", "datetime_col", "timestamp_col"],
+            ),
+            table_schema=[
+                {"name": "row_num", "type": "INTEGER"},
+                {"name": "date_col", "type": "DATE"},
+                {"name": "datetime_col", "type": "DATETIME"},
+                {"name": "timestamp_col", "type": "TIMESTAMP"},
+            ],
+        ),
+        id="issue365-extreme-datetimes",
+    ),
 ]
 
 

--- a/tests/system/test_to_gbq.py
+++ b/tests/system/test_to_gbq.py
@@ -201,29 +201,29 @@ DATAFRAME_ROUND_TRIPS = [
                         datetime.date(1970, 1, 1),
                         datetime.date(9999, 12, 31),
                     ],
-                    # DATETIME values outside of the range for pandas timestamp
-                    # require `date_as_object` parameter in
+                    # TODO: DATETIME/TIMESTAMP values outside of the range for
+                    # pandas timestamp require `date_as_object` parameter in
                     # google-cloud-bigquery versions 1.x and 2.x.
                     # https://github.com/googleapis/python-bigquery-pandas/issues/365
-                    "datetime_col": [
-                        datetime.datetime(1, 1, 1),
-                        datetime.datetime(1970, 1, 1),
-                        datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
-                    ],
-                    "timestamp_col": [
-                        datetime.datetime(1, 1, 1, tzinfo=datetime.timezone.utc),
-                        datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
-                        datetime.datetime(
-                            9999,
-                            12,
-                            31,
-                            23,
-                            59,
-                            59,
-                            999999,
-                            tzinfo=datetime.timezone.utc,
-                        ),
-                    ],
+                    # "datetime_col": [
+                    #     datetime.datetime(1, 1, 1),
+                    #     datetime.datetime(1970, 1, 1),
+                    #     datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
+                    # ],
+                    # "timestamp_col": [
+                    #     datetime.datetime(1, 1, 1, tzinfo=datetime.timezone.utc),
+                    #     datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+                    #     datetime.datetime(
+                    #         9999,
+                    #         12,
+                    #         31,
+                    #         23,
+                    #         59,
+                    #         59,
+                    #         999999,
+                    #         tzinfo=datetime.timezone.utc,
+                    #     ),
+                    # ],
                 },
                 columns=["row_num", "date_col", "datetime_col", "timestamp_col"],
             ),


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #441 
Towards #365 
🦕
