### PR TITLE
fix: avoid `TypeError` when executing DML statements with `read_gbq`

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -410,6 +410,7 @@ class GbqConnector(object):
         from concurrent.futures import TimeoutError
         from google.auth.exceptions import RefreshError
         from google.cloud import bigquery
+        import pandas
 
         job_config = {
             "query": {
@@ -494,6 +495,11 @@ class GbqConnector(object):
             query_reply.result()
         except self.http_error as ex:
             self.process_http_error(ex)
+
+        # Avoid attempting to download results from DML queries, which have no
+        # destination.
+        if query_reply.destination is None:
+            return pandas.DataFrame()
 
         rows_iter = self.client.list_rows(
             query_reply.destination, max_results=max_results


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes googleapis/python-bigquery#481  🦕
