### PR TITLE
fix: avoid deprecated "out-of-band" authentication flow

### DIFF
--- a/docs/howto/authentication.rst
+++ b/docs/howto/authentication.rst
@@ -159,7 +159,7 @@ credentials are not found.
        # Note, this doesn't work if you're running from a notebook on a
        # remote sever, such as over SSH or with Google Colab. In those cases,
        # install the gcloud command line interface and authenticate with the
-       # `gcloud auth application-default login` command an the `--no-browser`
+       # `gcloud auth application-default login` command and the `--no-browser`
        # option.
        auth_local_webserver=True,
    )

--- a/docs/howto/authentication.rst
+++ b/docs/howto/authentication.rst
@@ -156,9 +156,11 @@ credentials are not found.
 
    credentials = pydata_google_auth.get_user_credentials(
        SCOPES,
-       # Set auth_local_webserver to True to have a slightly more convienient
-       # authorization flow. Note, this doesn't work if you're running from a
-       # notebook on a remote sever, such as over SSH or with Google Colab.
+       # Note, this doesn't work if you're running from a notebook on a
+       # remote sever, such as over SSH or with Google Colab. In those cases,
+       # install the gcloud command line interface and authenticate with the
+       # `gcloud auth application-default login` command an the `--no-browser`
+       # option.
        auth_local_webserver=True,
    )
 

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -28,7 +28,7 @@ CLIENT_SECRET = "4hqze9yI8fxShls8eJWkeMdJ"
 
 
 def get_credentials(
-    private_key=None, project_id=None, reauth=False, auth_local_webserver=False
+    private_key=None, project_id=None, reauth=False, auth_local_webserver=True
 ):
     import pydata_google_auth
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -281,7 +281,7 @@ class GbqConnector(object):
         project_id,
         reauth=False,
         private_key=None,
-        auth_local_webserver=False,
+        auth_local_webserver=True,
         dialect="standard",
         location=None,
         credentials=None,
@@ -722,7 +722,7 @@ def read_gbq(
     index_col=None,
     col_order=None,
     reauth=False,
-    auth_local_webserver=False,
+    auth_local_webserver=True,
     dialect=None,
     location=None,
     configuration=None,
@@ -762,7 +762,7 @@ def read_gbq(
     reauth : boolean, default False
         Force Google BigQuery to re-authenticate the user. This is useful
         if multiple accounts are used.
-    auth_local_webserver : bool, default False
+    auth_local_webserver : bool, default True
         Use the `local webserver flow
         <https://googleapis.dev/python/google-auth-oauthlib/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_local_server>`_
         instead of the `console flow
@@ -959,7 +959,7 @@ def to_gbq(
     chunksize=None,
     reauth=False,
     if_exists="fail",
-    auth_local_webserver=False,
+    auth_local_webserver=True,
     table_schema=None,
     location=None,
     progress_bar=True,
@@ -1005,7 +1005,7 @@ def to_gbq(
             If table exists, drop it, recreate it, and insert data.
         ``'append'``
             If table exists, insert data. Create if does not exist.
-    auth_local_webserver : bool, default False
+    auth_local_webserver : bool, default True
         Use the `local webserver flow
         <https://googleapis.dev/python/google-auth-oauthlib/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_local_server>`_
         instead of the `console flow


### PR DESCRIPTION
The console-based copy-paste-a-token flow has been deprecated. See:
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html?m=1#disallowed-oob

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
