### PR TITLE
fix: updates requirements.txt to fix failing tests due to missing req

### DIFF
--- a/samples/snippets/requirements.txt
+++ b/samples/snippets/requirements.txt
@@ -1,5 +1,6 @@
 google-cloud-bigquery-storage==2.15.0
 google-cloud-bigquery==3.3.2
+pandas-gbq==0.17.8
 pandas===1.3.5; python_version == '3.7'
 pandas==1.4.4; python_version >= '3.8'
 pyarrow==9.0.0


### PR DESCRIPTION
Periodic tests were failing due to a missing reference to `pandas-gbq` in the `samples/snippets/requirements.txt` file.

This update remedies that issue.

Fixes #574 🦕
