### PR TITLE
chore: update the minimum protobuf version to 3.19.5 in python 3.7 unit test

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -16,4 +16,4 @@ pandas==0.24.2
 pyarrow==3.0.0
 pydata-google-auth==0.1.2
 tqdm==4.23.0
-protobuf==3.20.2
+protobuf==3.19.5


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: update the minimum protobuf version to 3.19.5 in python 3.7 unit test
END_COMMIT_OVERRIDE