### PR TITLE
feat: adds ability to provide redirect uri

### DIFF
--- a/docs/_static/js/authcodescripts.js
+++ b/docs/_static/js/authcodescripts.js
@@ -1,3 +1,10 @@
+
+
+// Copyright (c) 2023 pandas-gbq Authors All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+
 function onloadoauthcode() {
     const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
         get: (searchParams, prop) => searchParams.get(prop),

--- a/docs/_static/js/authcodescripts.js
+++ b/docs/_static/js/authcodescripts.js
@@ -1,0 +1,31 @@
+function onload() {
+    alert("Hello! DINOSAUR!");
+    const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
+        get: (searchParams, prop) => searchParams.get(prop),
+    });
+    const AUTH_CODE = PARAMS.code;
+
+    document.querySelector('.auth-code').textContent = AUTH_CODE;
+
+    setupCopyButton(document.querySelector('.copy'), AUTH_CODE);
+}
+
+function setupCopyButton(button, text) {
+    button.addEventListener('click', () => {
+        navigator.clipboard.writeText(text);
+        button.textContent = "Verification Code Copied";
+        setTimeout(() => {
+            // Remove the aria-live label so that when the
+            // button text changes back to "Copy", it is
+            // not read out.
+            button.removeAttribute("aria-live");
+            button.textContent = "Copy";
+        }, 1000);
+
+        // Re-Add the aria-live attribute to enable speech for
+        // when button text changes next time.
+        setTimeout(() => {
+            button.setAttribute("aria-live", "assertive");
+        }, 2000);
+    });
+}

--- a/docs/_static/js/authcodescripts.js
+++ b/docs/_static/js/authcodescripts.js
@@ -1,5 +1,4 @@
-function onload() {
-    alert("Hello! DINOSAUR!");
+function onloadoauthcode() {
     const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
         get: (searchParams, prop) => searchParams.get(prop),
     });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,10 +222,6 @@ html_static_path = ["_static"]
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 # html_show_sphinx = True
 
-html_js_files = [
-    "js/authcodescripts.js",
-]
-
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ html_static_path = ["_static"]
 # html_show_sphinx = True
 
 html_js_files = [
-    'js/authcodescript.js',
+    'js/authcodescripts.js',
 ]
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ html_static_path = ["_static"]
 # html_show_sphinx = True
 
 html_js_files = [
-    'js/authcodescripts.js',
+    "js/authcodescripts.js",
 ]
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,6 +222,10 @@ html_static_path = ["_static"]
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 # html_show_sphinx = True
 
+html_js_files = [
+    'js/authcodescript.js',
+]
+
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contents:
    contributing.rst
    changelog.md
    privacy.rst
+   oauth.rst
 
 
 Indices and tables

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -1,0 +1,65 @@
+.. image:: https://lh3.googleusercontent.com/KaU6SyiIpDKe4tyGPgt7yzGVTsfMqBvP9bL24o_4M58puYDO-nY8-BazrNk3RyhRFJA
+   :alt: gcloud CLI logo
+   :class: logo
+
+Sign in to OAuth-Testing-Mode Project
+=====================================
+
+DINOSAURS 3!
+
+You are seeing this page because you are attempting to access ... from
+this or another machine. If this is not the case, close this tab.
+
+Enter the following verification code in the CLI on the machine you want
+to log into. This is a credential **similar to your password** and
+should not be shared with others.
+
+
+.. raw:: html
+
+   <script type="text/javascript">
+      alert("Hello! DINOSAUR! basic test of script tag");
+   </script> 
+
+   <script type="text/javascript">
+   window.addEventListener( "load", completed ) {
+    alert("Hello! DINOSAUR! this is inside of window.add()");
+    const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
+        get: (searchParams, prop) => searchParams.get(prop),
+    });
+    const AUTH_CODE = PARAMS.code;
+
+    document.querySelector('.auth-code').textContent = AUTH_CODE;
+
+    setupCopyButton(document.querySelector('.copy'), AUTH_CODE);
+   }
+
+   function setupCopyButton(button, text) {
+      button.addEventListener('click', () => {
+         navigator.clipboard.writeText(text);
+         button.textContent = "Verification Code Copied";
+         setTimeout(() => {
+               // Remove the aria-live label so that when the
+               // button text changes back to "Copy", it is
+               // not read out.
+               button.removeAttribute("aria-live");
+               button.textContent = "Copy";
+         }, 1000);
+
+         // Re-Add the aria-live attribute to enable speech for
+         // when button text changes next time.
+         setTimeout(() => {
+               button.setAttribute("aria-live", "assertive");
+         }, 2000);
+      });
+   }
+   </script>
+
+   <div>
+      <code class="auth-code"></code>
+   </div>
+   <button class="copy" aria-live="assertive">Copy</button>
+
+.. hint::
+
+   You can close this tab when you’re done.

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -5,8 +5,6 @@
 Sign in to OAuth-Testing-Mode Project
 =====================================
 
-DINOSAURS 3!
-
 You are seeing this page because you are attempting to access ... from
 this or another machine. If this is not the case, close this tab.
 
@@ -23,7 +21,7 @@ should not be shared with others.
 
    <script type="text/javascript">
    window.addEventListener( "load", completed ) {
-    alert("Hello! DINOSAUR! this is inside of window.add()");
+    alert("Hello! DINOSAUR! this is inside of window.addEventListener() function");
     const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
         get: (searchParams, prop) => searchParams.get(prop),
     });

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -16,41 +16,7 @@ should not be shared with others.
 .. raw:: html
 
    <script type="text/javascript">
-      alert("Hello! DINOSAUR! basic test of script tag");
-   </script> 
-
-   <script type="text/javascript">
-   window.addEventListener( "load", completed ) {
-    alert("Hello! DINOSAUR! this is inside of window.addEventListener() function");
-    const PARAMS = new Proxy(new URLSearchParams(window.location.search), {
-        get: (searchParams, prop) => searchParams.get(prop),
-    });
-    const AUTH_CODE = PARAMS.code;
-
-    document.querySelector('.auth-code').textContent = AUTH_CODE;
-
-    setupCopyButton(document.querySelector('.copy'), AUTH_CODE);
-   }
-
-   function setupCopyButton(button, text) {
-      button.addEventListener('click', () => {
-         navigator.clipboard.writeText(text);
-         button.textContent = "Verification Code Copied";
-         setTimeout(() => {
-               // Remove the aria-live label so that when the
-               // button text changes back to "Copy", it is
-               // not read out.
-               button.removeAttribute("aria-live");
-               button.textContent = "Copy";
-         }, 1000);
-
-         // Re-Add the aria-live attribute to enable speech for
-         // when button text changes next time.
-         setTimeout(() => {
-               button.setAttribute("aria-live", "assertive");
-         }, 2000);
-      });
-   }
+     window.addEventListener( "load", onloadoauthcode )
    </script>
 
    <div>

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -2,15 +2,24 @@
    :alt: gcloud CLI logo
    :class: logo
 
-Sign in to OAuth-Testing-Mode Project
-=====================================
+Sign in to BigQuery
+===================
 
-You are seeing this page because you are attempting to access ... from
-this or another machine. If this is not the case, close this tab.
+You are seeing this page because you are attempting to access BigQuery via one 
+of several possible methods, including: 
+  
+  * the ``pandas_gbq`` library (https://github.com/googleapis/python-bigquery-pandas)
 
-Enter the following verification code in the CLI on the machine you want
-to log into. This is a credential **similar to your password** and
-should not be shared with others.
+  OR a ``pandas`` library helper function such as:
+  
+  * ``pandas.DataFrame.to_gbq()``
+  * ``pandas.read_gbq()``
+
+from this or another machine. If this is not the case, close this tab.
+
+Enter the following verification code in the CommandLine Interface (CLI) on the
+machine you want to log into. This is a credential **similar to your password**
+and should not be shared with others.
 
 
 .. raw:: html
@@ -22,6 +31,7 @@ should not be shared with others.
    <div>
       <code class="auth-code"></code>
    </div>
+   <br>
    <button class="copy" aria-live="assertive">Copy</button>
 
 .. hint::

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -28,7 +28,13 @@ CLIENT_SECRET = "4hqze9yI8fxShls8eJWkeMdJ"
 
 
 def get_credentials(
-    private_key=None, project_id=None, reauth=False, auth_local_webserver=True
+    private_key=None,
+    project_id=None,
+    reauth=False,
+    auth_local_webserver=True,
+    redirect_uri=None,
+    client_id=None,
+    client_secret=None,
 ):
     import pydata_google_auth
 
@@ -43,10 +49,11 @@ method from the google-auth package."""
 
     credentials, default_project_id = pydata_google_auth.default(
         SCOPES,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        client_id=client_id,
+        client_secret=client_secret,
         credentials_cache=get_credentials_cache(reauth),
         auth_local_webserver=auth_local_webserver,
+        redirect_uri=redirect_uri,
     )
 
     project_id = project_id or default_project_id

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -32,7 +32,7 @@ def get_credentials(
     project_id=None,
     reauth=False,
     auth_local_webserver=True,
-    redirect_uri=None,
+    auth_redirect_uri=None,
     client_id=None,
     client_secret=None,
 ):
@@ -53,7 +53,7 @@ method from the google-auth package."""
         client_secret=client_secret,
         credentials_cache=get_credentials_cache(reauth),
         auth_local_webserver=auth_local_webserver,
-        redirect_uri=redirect_uri,
+        auth_redirect_uri=auth_redirect_uri,
     )
 
     project_id = project_id or default_project_id

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -47,6 +47,12 @@ google.oauth2.service_account.Credentials.from_service_account_info class
 method from the google-auth package."""
         )
 
+    if client_id is None:
+        client_id = CLIENT_ID
+
+    if client_secret is None:
+        client_secret = CLIENT_SECRET
+
     credentials, default_project_id = pydata_google_auth.default(
         SCOPES,
         client_id=client_id,

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -53,7 +53,7 @@ method from the google-auth package."""
         client_secret=client_secret,
         credentials_cache=get_credentials_cache(reauth),
         auth_local_webserver=auth_local_webserver,
-        auth_redirect_uri=auth_redirect_uri,
+        redirect_uri=auth_redirect_uri,
     )
 
     project_id = project_id or default_project_id

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -280,6 +280,9 @@ class GbqConnector(object):
         location=None,
         credentials=None,
         use_bqstorage_api=False,
+        redirect_uri=None,
+        client_id=None,
+        client_secret=None,
     ):
         global context
         from google.api_core.exceptions import GoogleAPIError
@@ -294,6 +297,10 @@ class GbqConnector(object):
         self.auth_local_webserver = auth_local_webserver
         self.dialect = dialect
         self.credentials = credentials
+        self.redirect_uri = redirect_uri
+        self.client_id = client_id
+        self.client_secret = client_secret
+        
         default_project = None
 
         # Service account credentials have a project associated with them.
@@ -313,6 +320,10 @@ class GbqConnector(object):
                 project_id=project_id,
                 reauth=reauth,
                 auth_local_webserver=auth_local_webserver,
+                redirect_uri=redirect_uri,
+                client_id=client_id,
+                client_secret=client_secret,
+
             )
 
         if self.project_id is None:
@@ -735,6 +746,10 @@ def read_gbq(
     private_key=None,
     progress_bar_type="tqdm",
     dtypes=None,
+    redirect_uri=None,
+    client_id=None,
+    client_secret=None,
+
 ):
     r"""Load data from Google BigQuery using google-cloud-python
 
@@ -864,6 +879,8 @@ def read_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
+    # TODO: add parameters for redirect_uri, client_id, client_secret
+
 
     Returns
     -------
@@ -912,6 +929,10 @@ def read_gbq(
         credentials=credentials,
         private_key=private_key,
         use_bqstorage_api=use_bqstorage_api,
+        redirect_uri=redirect_uri,
+        client_id=client_id,
+        client_secret=client_secret,
+
     )
 
     if _is_query(query_or_table):

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -877,8 +877,15 @@ def read_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
-    # TODO: add parameters for auth_redirect_uri, client_id, client_secret
-
+    auth_redirect_uri : str
+        Path to the authentication page for organization-specific authentication
+        workflows.
+    client_id : str
+        The Client ID for the Google Cloud Project the user is attempting to
+        connect to.
+    client_secret : str
+        The Client Secret associated with the Client ID for the Google Cloud Project
+        the user is attempting to connect to.
 
     Returns
     -------
@@ -1092,8 +1099,15 @@ def to_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
-    #TODO add parameters for auth_redirect, client_id, client_secret
-
+    auth_redirect_uri : str
+        Path to the authentication page for organization-specific authentication
+        workflows.
+    client_id : str
+        The Client ID for the Google Cloud Project the user is attempting to
+        connect to.
+    client_secret : str
+        The Client Secret associated with the Client ID for the Google Cloud Project
+        the user is attempting to connect to.
     """
 
     _test_google_api_imports()

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -300,7 +300,7 @@ class GbqConnector(object):
         self.auth_redirect_uri = auth_redirect_uri
         self.client_id = client_id
         self.client_secret = client_secret
-        
+
         default_project = None
 
         # Service account credentials have a project associated with them.
@@ -323,7 +323,6 @@ class GbqConnector(object):
                 auth_redirect_uri=auth_redirect_uri,
                 client_id=client_id,
                 client_secret=client_secret,
-
             )
 
         if self.project_id is None:
@@ -749,7 +748,6 @@ def read_gbq(
     auth_redirect_uri=None,
     client_id=None,
     client_secret=None,
-
 ):
     r"""Load data from Google BigQuery using google-cloud-python
 
@@ -932,7 +930,6 @@ def read_gbq(
         auth_redirect_uri=auth_redirect_uri,
         client_id=client_id,
         client_secret=client_secret,
-
     )
 
     if _is_query(query_or_table):

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -280,7 +280,7 @@ class GbqConnector(object):
         location=None,
         credentials=None,
         use_bqstorage_api=False,
-        redirect_uri=None,
+        auth_redirect_uri=None,
         client_id=None,
         client_secret=None,
     ):
@@ -297,7 +297,7 @@ class GbqConnector(object):
         self.auth_local_webserver = auth_local_webserver
         self.dialect = dialect
         self.credentials = credentials
-        self.redirect_uri = redirect_uri
+        self.auth_redirect_uri = auth_redirect_uri
         self.client_id = client_id
         self.client_secret = client_secret
         
@@ -320,7 +320,7 @@ class GbqConnector(object):
                 project_id=project_id,
                 reauth=reauth,
                 auth_local_webserver=auth_local_webserver,
-                redirect_uri=redirect_uri,
+                auth_redirect_uri=auth_redirect_uri,
                 client_id=client_id,
                 client_secret=client_secret,
 
@@ -746,7 +746,7 @@ def read_gbq(
     private_key=None,
     progress_bar_type="tqdm",
     dtypes=None,
-    redirect_uri=None,
+    auth_redirect_uri=None,
     client_id=None,
     client_secret=None,
 
@@ -879,7 +879,7 @@ def read_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
-    # TODO: add parameters for redirect_uri, client_id, client_secret
+    # TODO: add parameters for auth_redirect_uri, client_id, client_secret
 
 
     Returns
@@ -929,7 +929,7 @@ def read_gbq(
         credentials=credentials,
         private_key=private_key,
         use_bqstorage_api=use_bqstorage_api,
-        redirect_uri=redirect_uri,
+        auth_redirect_uri=auth_redirect_uri,
         client_id=client_id,
         client_secret=client_secret,
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -879,7 +879,7 @@ def read_gbq(
         instead.
     auth_redirect_uri : str
         Path to the authentication page for organization-specific authentication
-        workflows.
+        workflows. Used when `auth_local_webserver=False`.
     client_id : str
         The Client ID for the Google Cloud Project the user is attempting to
         connect to.
@@ -1101,7 +1101,7 @@ def to_gbq(
         instead.
     auth_redirect_uri : str
         Path to the authentication page for organization-specific authentication
-        workflows.
+        workflows. Used when `auth_local_webserver=False`.
     client_id : str
         The Client ID for the Google Cloud Project the user is attempting to
         connect to.

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -987,6 +987,9 @@ def to_gbq(
     api_method: str = "default",
     verbose=None,
     private_key=None,
+    auth_redirect_uri=None,
+    client_id=None,
+    client_secret=None,
 ):
     """Write a DataFrame to a Google BigQuery table.
 
@@ -1089,6 +1092,8 @@ def to_gbq(
         or
         :func:`google.oauth2.service_account.Credentials.from_service_account_file`
         instead.
+    #TODO add parameters for auth_redirect, client_id, client_secret
+
     """
 
     _test_google_api_imports()
@@ -1149,6 +1154,9 @@ def to_gbq(
         location=location,
         credentials=credentials,
         private_key=private_key,
+        auth_redirect_uri=auth_redirect_uri,
+        client_id=client_id,
+        client_secret=client_secret,
     )
     bqclient = connector.client
 

--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -879,7 +879,7 @@ def read_gbq(
         instead.
     auth_redirect_uri : str
         Path to the authentication page for organization-specific authentication
-        workflows. Used when `auth_local_webserver=False`.
+        workflows. Used when ``auth_local_webserver=False``.
     client_id : str
         The Client ID for the Google Cloud Project the user is attempting to
         connect to.
@@ -1101,7 +1101,7 @@ def to_gbq(
         instead.
     auth_redirect_uri : str
         Path to the authentication page for organization-specific authentication
-        workflows. Used when `auth_local_webserver=False`.
+        workflows. Used when ``auth_local_webserver=False``.
     client_id : str
         The Client ID for the Google Cloud Project the user is attempting to
         connect to.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ dependencies = [
     "numpy >=1.16.6",
     "pandas >=1.1.4",
     "pyarrow >=3.0.0",
-    "pydata-google-auth >=1.4.0",
+    "pydata-google-auth >=1.5.0",
     # Note: google-api-core and google-auth are also included via transitive
     # dependency on google-cloud-bigquery, but this library also uses them
     # directly.

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -14,6 +14,6 @@ google-cloud-bigquery-storage==2.16.2
 numpy==1.16.6
 pandas==1.1.4
 pyarrow==3.0.0
-pydata-google-auth==1.4.0
+pydata-google-auth==1.5.0
 tqdm==4.23.0
 protobuf==3.19.5


### PR DESCRIPTION
WIP PR for discussion: aiming to provide the ability to include a redirect URI, client ID, and client secrets to facilitate the migration away from "out of band" OAuth authentication.

@tswast 

For context, there are changes in these repos:
* https://github.com/googleapis/python-bigquery-pandas/pull/595 #python-bigquery-pandas
* https://github.com/pydata/pydata-google-auth/pull/58 (Non-google repository)