### PR TITLE
chore: updates python version to 3.11

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9 and 3.10 on both UNIX and Windows.
+  3.7, 3.8, 3.9, 3.10 and 3.11 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -72,7 +72,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To run a single unit test::
 
-    $ nox -s unit-3.10 -- -k <name of test>
+    $ nox -s unit-3.11 -- -k <name of test>
 
 
   .. note::
@@ -143,12 +143,12 @@ Running System Tests
    $ nox -s system
 
    # Run a single system test
-   $ nox -s system-3.10 -- -k <name of test>
+   $ nox -s system-3.11 -- -k <name of test>
 
 
   .. note::
 
-      System tests are only configured to run under Python 3.7, 3.8, 3.9 and 3.10.
+      System tests are only configured to run under Python 3.7, 3.8, 3.9, 3.10 and 3.11.
       For expediency, we do not run them in older versions of Python 3.
 
   This alone will not run the tests. You'll need to change some local
@@ -225,11 +225,13 @@ We support:
 -  `Python 3.8`_
 -  `Python 3.9`_
 -  `Python 3.10`_
+-  `Python 3.11`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
 .. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
+.. _Python 3.11: https://docs.python.org/3.11/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ LINT_PATHS = ["docs", "pandas_gbq", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
 
-UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "asyncmock",
@@ -51,7 +51,7 @@ UNIT_TEST_EXTRAS_BY_PYTHON = {
     "3.9": [],
 }
 
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",

--- a/owlbot.py
+++ b/owlbot.py
@@ -35,8 +35,8 @@ extras_by_python = {
 }
 extras = ["tqdm"]
 templated_files = common.py_library(
-    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10"],
-    system_test_python_versions=["3.7", "3.8", "3.9", "3.10"],
+    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11"],
+    system_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11"],
     cov_level=96,
     unit_test_external_dependencies=["freezegun"],
     unit_test_extras=extras,


### PR DESCRIPTION
Introducing this for discussion. Planning on adding version 3.11 as a test platform. Not sure about all the inner workings behind our codebase, so there are prolly a number of things that need to be added/edited. Feel free to comment.

@tswast @parthea 
