### PR TITLE
docs: updates with a link to the canonical source of documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,9 @@ analytics web service to simplify retrieving results from BigQuery tables
 using SQL-like queries. Result sets are parsed into a :class:`pandas.DataFrame`
 with a shape and data types derived from the source table. Additionally,
 DataFrames can be inserted into new BigQuery tables or appended to existing
-tables. The canonical version of this documentation can always be found on the
+tables.
+
+Note:  The canonical version of this documentation can always be found on the
 `googleapis.dev pangas-gbq site
 <https://googleapis.dev/python/pandas-gbq/latest/index.html>`__.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,9 @@ analytics web service to simplify retrieving results from BigQuery tables
 using SQL-like queries. Result sets are parsed into a :class:`pandas.DataFrame`
 with a shape and data types derived from the source table. Additionally,
 DataFrames can be inserted into new BigQuery tables or appended to existing
-tables.
+tables. The canonical version of this documentation can always be found on the
+`googleapis.dev pangas-gbq site
+<https://googleapis.dev/python/pandas-gbq/latest/index.html>`__.
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ DataFrames can be inserted into new BigQuery tables or appended to existing
 tables.
 
 Note:  The canonical version of this documentation can always be found on the
-`googleapis.dev pangas-gbq site
+`googleapis.dev pandas-gbq site
 <https://googleapis.dev/python/pandas-gbq/latest/index.html>`__.
 
 .. note::


### PR DESCRIPTION
Adds a link to the canonical source of our documentation to protect against issues that may arise at Read The Docs if our docs build versions of Python ever get out of sync again.

Fixes #448 🦕
