### PR TITLE
fix: add exception context to GenericGBQExceptions

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -393,7 +393,7 @@ class GbqConnector(object):
             error_message = ex.errors[0]["message"]
             raise TableCreationError(f"Reason: {error_message}")
         else:
-            raise GenericGBQException("Reason: {0}".format(ex))
+            raise GenericGBQException("Reason: {0}".format(ex)) from ex
 
     def download_table(
         self,


### PR DESCRIPTION
The `from` keyword adds a `__cause__` parameter to the thrown exception. This allows external applications access to the originally thrown exception.

My required usecase: my application has experienced BQ rate limiting errors but I am only getting GenericGBQExceptions out the other side, this change will allow me to be more nuanced with my error handling and apply rate limiting pauses only when appropriate.