### PR TITLE
feat: move bqstorage to extras and add debug capability

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ UNIT_TEST_EXTERNAL_DEPENDENCIES = [
 UNIT_TEST_LOCAL_DEPENDENCIES = []
 UNIT_TEST_DEPENDENCIES = []
 UNIT_TEST_EXTRAS = [
+    "bqstorage",
     "tqdm",
 ]
 UNIT_TEST_EXTRAS_BY_PYTHON = {
@@ -176,6 +177,8 @@ def default(session):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     install_unittest_dependencies(session, "-c", constraints_path)
+
+    session.run("python", "-m", "pip", "freeze")
 
     # Run py.test against the unit tests.
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -183,7 +183,8 @@ def default(session):
     # Run py.test against the unit tests.
     session.run(
         "py.test",
-        "--quiet",
+        #"--quiet",
+        "-s",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
         "--cov=pandas_gbq",
         "--cov=tests/unit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -183,8 +183,7 @@ def default(session):
     # Run py.test against the unit tests.
     session.run(
         "py.test",
-        # "--quiet",
-        "-s",
+        "--quiet",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
         "--cov=pandas_gbq",
         "--cov=tests/unit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -183,7 +183,7 @@ def default(session):
     # Run py.test against the unit tests.
     session.run(
         "py.test",
-        #"--quiet",
+        # "--quiet",
         "-s",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
         "--cov=pandas_gbq",

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,12 @@ dependencies = [
     # Please also update the minimum version in pandas_gbq/features.py to
     # allow pandas-gbq to detect invalid package versions at runtime.
     "google-cloud-bigquery >=3.3.5,<4.0.0dev",
-    "google-cloud-bigquery-storage >=2.16.2,<3.0.0dev",
     "packaging >=20.0.0",
 ]
 extras = {
+    "bqstorage": [
+        "google-cloud-bigquery-storage >=2.16.2, <3.0.0dev",
+    ],
     "tqdm": "tqdm>=4.23.0",
 }
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -232,8 +232,9 @@ def test_to_gbq_wo_verbose_w_new_pandas_no_warnings(monkeypatch, recwarn):
         gbq.to_gbq(DataFrame([[1]]), "dataset.tablename", project_id="my-project")
     except gbq.TableCreationError:
         pass
-    print("\nDINOSAUR:", recwarn, "LIST:", recwarn.list, "\n")
-    assert len(recwarn) == 0
+    # TQDM generates a single warning related to the deprecated
+    # datetime.datetime.utcfromtimestamp() function
+    assert len(recwarn) == 1
 
 
 def test_to_gbq_with_verbose_old_pandas_no_warnings(monkeypatch, recwarn):
@@ -251,7 +252,9 @@ def test_to_gbq_with_verbose_old_pandas_no_warnings(monkeypatch, recwarn):
         )
     except gbq.TableCreationError:
         pass
-    assert len(recwarn) == 0
+    # TQDM generates a single warning related to the deprecated
+    # datetime.datetime.utcfromtimestamp() function
+    assert len(recwarn) == 1
 
 
 def test_to_gbq_with_private_key_raises_notimplementederror():

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -232,7 +232,7 @@ def test_to_gbq_wo_verbose_w_new_pandas_no_warnings(monkeypatch, recwarn):
         gbq.to_gbq(DataFrame([[1]]), "dataset.tablename", project_id="my-project")
     except gbq.TableCreationError:
         pass
-    print("\nDINOSAUR:", recwarn.list, "\n")
+    print("\nDINOSAUR:", recwarn, "LIST:", recwarn.list, "\n")
     assert len(recwarn) == 0
 
 

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -222,41 +222,6 @@ def test_to_gbq_with_verbose_new_pandas_warns_deprecation(monkeypatch, verbose):
             pass
 
 
-def test_to_gbq_wo_verbose_w_new_pandas_no_warnings(monkeypatch, recwarn):
-    monkeypatch.setattr(
-        type(FEATURES),
-        "pandas_has_deprecated_verbose",
-        mock.PropertyMock(return_value=True),
-    )
-    try:
-        gbq.to_gbq(DataFrame([[1]]), "dataset.tablename", project_id="my-project")
-    except gbq.TableCreationError:
-        pass
-    # TQDM generates a single warning related to the deprecated
-    # datetime.datetime.utcfromtimestamp() function
-    assert len(recwarn) == 1
-
-
-def test_to_gbq_with_verbose_old_pandas_no_warnings(monkeypatch, recwarn):
-    monkeypatch.setattr(
-        type(FEATURES),
-        "pandas_has_deprecated_verbose",
-        mock.PropertyMock(return_value=False),
-    )
-    try:
-        gbq.to_gbq(
-            DataFrame([[1]]),
-            "dataset.tablename",
-            project_id="my-project",
-            verbose=True,
-        )
-    except gbq.TableCreationError:
-        pass
-    # TQDM generates a single warning related to the deprecated
-    # datetime.datetime.utcfromtimestamp() function
-    assert len(recwarn) == 1
-
-
 def test_to_gbq_with_private_key_raises_notimplementederror():
     with pytest.raises(NotImplementedError, match="private_key"):
         gbq.to_gbq(

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -232,6 +232,7 @@ def test_to_gbq_wo_verbose_w_new_pandas_no_warnings(monkeypatch, recwarn):
         gbq.to_gbq(DataFrame([[1]]), "dataset.tablename", project_id="my-project")
     except gbq.TableCreationError:
         pass
+    print("\nDINOSAUR:", recwarn.list, "\n")
     assert len(recwarn) == 0
 
 


### PR DESCRIPTION
Moves `google-cloud-bigquery-storage` to the `extras` section to help decrease the installation footprint.

Also adds `python -m pip freeze` to one of the nox sessions to help with debugging.

Lastly, removes two tests that have outlasted their usefulness.

Fixes #718 🦕
