### PR TITLE
bug: add missing latency check

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -361,7 +361,7 @@ def prerelease(session):
         "py.test",
         "--quiet",
         f"--junitxml=prerelease_system_{session.python}_sponge_log.xml",
-        # os.path.join("tests", "system"),
+        os.path.join("tests", "system"),
         *session.posargs,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -348,7 +348,6 @@ def prerelease(session):
     session.run("python", "-m", "pip", "freeze")
 
     # Run all tests, except a few samples tests which require extra dependencies.
-
     session.run(
         "py.test",
         "--quiet",

--- a/noxfile.py
+++ b/noxfile.py
@@ -256,6 +256,9 @@ def system(session):
 
     install_systemtest_dependencies(session, "-c", constraints_path)
 
+    # Print out package versions.
+    session.run("python", "-m", "pip", "freeze")
+
     # Run py.test against the system tests.
     if system_test_exists:
         session.run(
@@ -514,7 +517,9 @@ def prerelease_deps(session):
     ]
     session.install(*other_deps)
 
-    # Print out prerelease package versions
+    # Print out package versions.
+    session.run("python", "-m", "pip", "freeze")
+
     session.run(
         "python", "-c", "import google.protobuf; print(google.protobuf.__version__)"
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -298,7 +298,7 @@ def prerelease(session):
         "--pre",
         "--upgrade",
         "google-api-core",
-        "google-cloud-bigquery",
+        "google-cloud-bigquery==3.20.1",
         "google-cloud-bigquery-storage",
         "google-cloud-core",
         "google-resumable-media",
@@ -350,12 +350,14 @@ def prerelease(session):
         "--quiet",
         f"--junitxml=prerelease_unit_{session.python}_sponge_log.xml",
         os.path.join("tests", "unit"),
+        *session.posargs,
     )
     session.run(
         "py.test",
         "--quiet",
         f"--junitxml=prerelease_system_{session.python}_sponge_log.xml",
         os.path.join("tests", "system"),
+        *session.posargs,
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -353,7 +353,7 @@ def prerelease(session):
         "py.test",
         "--quiet",
         f"--junitxml=prerelease_unit_{session.python}_sponge_log.xml",
-        # os.path.join("tests", "unit"),
+        os.path.join("tests", "unit"),
         *session.posargs,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -301,7 +301,7 @@ def prerelease(session):
         "--pre",
         "--upgrade",
         "google-api-core",
-        "google-cloud-bigquery==3.20.1",
+        "google-cloud-bigquery",
         "google-cloud-bigquery-storage",
         "google-cloud-core",
         "google-resumable-media",
@@ -348,18 +348,20 @@ def prerelease(session):
     session.run("python", "-m", "pip", "freeze")
 
     # Run all tests, except a few samples tests which require extra dependencies.
+
     session.run(
         "py.test",
         "--quiet",
         f"--junitxml=prerelease_unit_{session.python}_sponge_log.xml",
-        os.path.join("tests", "unit"),
+        # os.path.join("tests", "unit"),
         *session.posargs,
     )
+
     session.run(
         "py.test",
         "--quiet",
         f"--junitxml=prerelease_system_{session.python}_sponge_log.xml",
-        os.path.join("tests", "system"),
+        # os.path.join("tests", "system"),
         *session.posargs,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     "google-auth-oauthlib >=0.7.0",
     # Please also update the minimum version in pandas_gbq/features.py to
     # allow pandas-gbq to detect invalid package versions at runtime.
-    "google-cloud-bigquery >=3.3.5,!=3.21.0,<4.0.0dev",
+    "google-cloud-bigquery >=3.3.5,<4.0.0dev",
     "packaging >=20.0.0",
 ]
 extras = {

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     "google-auth-oauthlib >=0.7.0",
     # Please also update the minimum version in pandas_gbq/features.py to
     # allow pandas-gbq to detect invalid package versions at runtime.
-    "google-cloud-bigquery >=3.3.5,<4.0.0dev",
+    "google-cloud-bigquery >=3.3.5,!=3.21.0,<4.0.0dev",
     "packaging >=20.0.0",
 ]
 extras = {

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -475,7 +475,7 @@ class TestReadGBQIntegration(object):
         """
 
         # This first test confirms that we get a timeout error if we exceed the timeout limit.
-        # The above query is expected to take a long time and exceed the limit. 
+        # The above query is expected to take a long time and exceed the limit.
         configs = [
             # we have a minimum limit on the timeout_ms being 400 milliseconds
             # see pandas-gbq/gbq.py/GbqConnector/run_query docstring
@@ -494,18 +494,18 @@ class TestReadGBQIntegration(object):
                     credentials=self.credentials,
                     configuration=config,
                 )
-        
-        # This second test confirms out our validation logic won't allow a 
+
+        # This second test confirms out our validation logic won't allow a
         # value less than or equal to 400 be used as a timeout value.
         # by exercising the system for various edge cases to ensure we catch
         # invalid values less than or equal to 400.
         configs = [
             {"query": {"useQueryCache": False, "timeoutMs": 399}},
             {"query": {"useQueryCache": False, "timeoutMs": 400}},
-            {"query": {"useQueryCache": False, "timeoutMs": 1}},                        
+            {"query": {"useQueryCache": False, "timeoutMs": 1}},
             {"query": {"useQueryCache": False}, "jobTimeoutMs": 399},
             {"query": {"useQueryCache": False}, "jobTimeoutMs": 400},
-            {"query": {"useQueryCache": False}, "jobTimeoutMs": 1},                        
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 1},
         ]
 
         for config in configs:

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -474,11 +474,14 @@ class TestReadGBQIntegration(object):
         select count(*) from unnest(generate_array(1,1000000)), unnest(generate_array(1, 10000))
         """
         configs = [
+            # we have a minimum limit on the timeout_ms being 400 milliseconds
+            # see pandas-gbq/gbq.py/GbqConnector/run_query docstring
+            # for more details.
             # pandas-gbq timeout configuration. Transformed to REST API compatible version.
-            {"query": {"useQueryCache": False, "timeoutMs": 1}},
+            {"query": {"useQueryCache": False, "timeoutMs": 401}},
             # REST API job timeout. See:
             # https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfiguration.FIELDS.job_timeout_ms
-            {"query": {"useQueryCache": False}, "jobTimeoutMs": 1},
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 401},
         ]
         for config in configs:
             with pytest.raises(gbq.QueryTimeout):

--- a/tests/system/test_gbq.py
+++ b/tests/system/test_gbq.py
@@ -473,6 +473,9 @@ class TestReadGBQIntegration(object):
         sql_statement = """
         select count(*) from unnest(generate_array(1,1000000)), unnest(generate_array(1, 10000))
         """
+
+        # This first test confirms that we get a timeout error if we exceed the timeout limit.
+        # The above query is expected to take a long time and exceed the limit. 
         configs = [
             # we have a minimum limit on the timeout_ms being 400 milliseconds
             # see pandas-gbq/gbq.py/GbqConnector/run_query docstring
@@ -483,6 +486,28 @@ class TestReadGBQIntegration(object):
             # https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfiguration.FIELDS.job_timeout_ms
             {"query": {"useQueryCache": False}, "jobTimeoutMs": 401},
         ]
+        for config in configs:
+            with pytest.raises(gbq.QueryTimeout):
+                gbq.read_gbq(
+                    sql_statement,
+                    project_id=project_id,
+                    credentials=self.credentials,
+                    configuration=config,
+                )
+        
+        # This second test confirms out our validation logic won't allow a 
+        # value less than or equal to 400 be used as a timeout value.
+        # by exercising the system for various edge cases to ensure we catch
+        # invalid values less than or equal to 400.
+        configs = [
+            {"query": {"useQueryCache": False, "timeoutMs": 399}},
+            {"query": {"useQueryCache": False, "timeoutMs": 400}},
+            {"query": {"useQueryCache": False, "timeoutMs": 1}},                        
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 399},
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 400},
+            {"query": {"useQueryCache": False}, "jobTimeoutMs": 1},                        
+        ]
+
         for config in configs:
             with pytest.raises(gbq.QueryTimeout):
                 gbq.read_gbq(


### PR DESCRIPTION
There is a failing flakybot test. This PR provides a possible mitigation.
During a recent PR, we appear to have introduced a situation that occurs when we attempt to perform certain actions without recognizing that there will be some latency in the system. This adds checks to account for that latency.

Fixes #762 