### PR TITLE
feat: Adds pip freeze to several sessions in the noxfile to aid in troubleshooting

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -513,7 +513,7 @@ def prerelease_deps(session):
         "requests",
     ]
     session.install(*other_deps)
-    session.run("python", "-m", "pip", "freeze")  
+    session.run("python", "-m", "pip", "freeze")
 
     # Print out prerelease package versions
     session.run(
@@ -525,7 +525,6 @@ def prerelease_deps(session):
 
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
-
 
     # Only run system tests if found.
     if os.path.exists(system_test_path):

--- a/noxfile.py
+++ b/noxfile.py
@@ -256,6 +256,8 @@ def system(session):
 
     install_systemtest_dependencies(session, "-c", constraints_path)
 
+    session.run("python", "-m", "pip", "freeze")
+
     # Run py.test against the system tests.
     if system_test_exists:
         session.run(
@@ -511,6 +513,7 @@ def prerelease_deps(session):
         "requests",
     ]
     session.install(*other_deps)
+    session.run("python", "-m", "pip", "freeze")  
 
     # Print out prerelease package versions
     session.run(
@@ -522,6 +525,7 @@ def prerelease_deps(session):
 
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
+
 
     # Only run system tests if found.
     if os.path.exists(system_test_path):


### PR DESCRIPTION
Adds the pip freeze command to several sessions in the noxfile to aid in troubleshooting.
When tests fail, especially with older versions of the code it is sometimes useful to know what versions of the dependencies have been installed.
