### PR TITLE
fix: clean up code that displays versions used in testing for debug purposes

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -302,7 +302,7 @@ def prerelease(session):
         "--pre",
         "--upgrade",
         "google-api-core",
-        "google-cloud-bigquery",
+        "google-cloud-bigquery==3.20.1",
         "google-cloud-bigquery-storage",
         "google-cloud-core",
         "google-resumable-media",


### PR DESCRIPTION
Cleaned up several items in the noxfile to faciliate debugging.
* Due to additions of `python -m pip freeze` commands, removed several package-specific version display expressions since they are now redundant.
* Removed a duplicative line with `python -m pip freeze`

