### PR TITLE
fix: clean up nox sessions to uniformly displays package versions for debug purposes

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -527,15 +527,9 @@ def prerelease_deps(session):
         "requests",
     ]
     session.install(*other_deps)
-    session.run("python", "-m", "pip", "freeze")
 
     # Print out package versions.
     session.run("python", "-m", "pip", "freeze")
-
-    session.run(
-        "python", "-c", "import google.protobuf; print(google.protobuf.__version__)"
-    )
-    session.run("python", "-c", "import grpc; print(grpc.__version__)")
 
     session.run("py.test", "tests/unit")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -302,7 +302,7 @@ def prerelease(session):
         "--pre",
         "--upgrade",
         "google-api-core",
-        "google-cloud-bigquery",
+        "google-cloud-bigquery==3.20.1",
         "google-cloud-bigquery-storage",
         "google-cloud-core",
         "google-resumable-media",

--- a/noxfile.py
+++ b/noxfile.py
@@ -302,7 +302,7 @@ def prerelease(session):
         "--pre",
         "--upgrade",
         "google-api-core",
-        "google-cloud-bigquery==3.20.1",
+        "google-cloud-bigquery",
         "google-cloud-bigquery-storage",
         "google-cloud-core",
         "google-resumable-media",


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: clean up nox sessions to uniformly displays package versions for debug purposes (#777)
END_COMMIT_OVERRIDE

Cleaned up several items in the noxfile to faciliate debugging.
* Due to additions of `python -m pip freeze` commands, removed several package-specific version display expressions since they are now redundant.
* Removed a duplicative line with `python -m pip freeze`
