### PR TITLE
fix: set minimum allowable version of sqlite when performing a conda install

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -607,7 +607,7 @@ def conda_test(session):
         "pydata-google-auth",
         "tqdm",
         "protobuf",
-        "sqlite>=3.31.1", # v3.31.1 caused test failures
+        "sqlite>=3.31.1",  # v3.31.1 caused test failures
     ]
 
     install_conda_unittest_dependencies(session, standard_deps, conda_forge_packages)

--- a/noxfile.py
+++ b/noxfile.py
@@ -607,6 +607,7 @@ def conda_test(session):
         "pydata-google-auth",
         "tqdm",
         "protobuf",
+        "sqlite>=3.31.1", # v3.31.1 caused test failures
     ]
 
     install_conda_unittest_dependencies(session, standard_deps, conda_forge_packages)

--- a/noxfile.py
+++ b/noxfile.py
@@ -607,7 +607,7 @@ def conda_test(session):
         "pydata-google-auth",
         "tqdm",
         "protobuf",
-        "sqlite>=3.31.1",  # v3.31.1 caused test failures
+        "sqlite>3.31.1",  # v3.31.1 caused test failures
     ]
 
     install_conda_unittest_dependencies(session, standard_deps, conda_forge_packages)


### PR DESCRIPTION
Fix: sets minimum allowable version of `sqlite` when performing a `conda` install. Conda installs were killing the install of packages in the presubmit `conda_test-3.12` test.

See this [check for context](https://source.cloud.google.com/results/invocations/beabfa58-9228-40fb-a60b-48df1944b159).

