### PR TITLE
test: adds a config to isolate the system- CI/CD tests

### DIFF
--- a/.kokoro/presubmit/system-3.12.cfg
+++ b/.kokoro/presubmit/system-3.12.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run the following session(s)
+env_vars: {
+  key: "NOX_SESSION"
+  value: "system-3.12"
+}

--- a/.kokoro/presubmit/system-3.8.cfg
+++ b/.kokoro/presubmit/system-3.8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run the following session(s)
+env_vars: {
+  key: "NOX_SESSION"
+  value: "system-3.8"
+}


### PR DESCRIPTION
Adds a config to isolate the system-3.8 and system-3.12 CI/CD tests from the presubmit job into two separate jobs to increase parallelism.