### PR TITLE
fix(deps): require packaging >= 22.0

### DIFF
--- a/pandas_gbq/features.py
+++ b/pandas_gbq/features.py
@@ -5,7 +5,7 @@
 """Module for checking dependency versions and supported features."""
 
 # https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md
-BIGQUERY_MINIMUM_VERSION = "3.3.5"
+BIGQUERY_MINIMUM_VERSION = "3.4.2"
 BIGQUERY_QUERY_AND_WAIT_VERSION = "3.14.0"
 PANDAS_VERBOSITY_DEPRECATION_VERSION = "0.23.0"
 PANDAS_BOOLEAN_DTYPE_VERSION = "1.0.0"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     # Please also update the minimum version in pandas_gbq/features.py to
     # allow pandas-gbq to detect invalid package versions at runtime.
     "google-cloud-bigquery >=3.3.5,<4.0.0dev",
-    "packaging >=20.0.0",
+    "packaging >=22.0.0",
 ]
 extras = {
     "bqstorage": [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "setuptools",
     "db-dtypes >=1.0.4,<2.0.0",
-    "numpy >=1.16.6",
+    "numpy >=1.18.1",
     "pandas >=1.1.4",
     "pyarrow >=3.0.0",
     "pydata-google-auth >=1.5.0",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dependencies = [
     "google-auth-oauthlib >=0.7.0",
     # Please also update the minimum version in pandas_gbq/features.py to
     # allow pandas-gbq to detect invalid package versions at runtime.
-    "google-cloud-bigquery >=3.3.5,<4.0.0dev",
+    "google-cloud-bigquery >=3.4.2,<4.0.0dev",
     "packaging >=22.0.0",
 ]
 extras = {

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -12,7 +12,7 @@ google-auth==2.13.0
 google-auth-oauthlib==0.7.0
 google-cloud-bigquery==3.4.2
 google-cloud-bigquery-storage==2.16.2
-numpy==1.16.6
+numpy==1.18.1
 pandas==1.1.4
 pyarrow==3.0.0
 pydata-google-auth==1.5.0

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -10,7 +10,7 @@ db-dtypes==1.0.4
 google-api-core==2.10.2
 google-auth==2.13.0
 google-auth-oauthlib==0.7.0
-google-cloud-bigquery==3.3.5
+google-cloud-bigquery==3.4.2
 google-cloud-bigquery-storage==2.16.2
 numpy==1.16.6
 pandas==1.1.4

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -17,4 +17,4 @@ pandas==1.1.4
 pyarrow==3.0.0
 pydata-google-auth==1.5.0
 tqdm==4.23.0
-packaging==20.0.0
+packaging==22.0.0


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(deps): require packaging >= 22.0
fix(deps): require google-cloud-bigquery >= 3.4.2
fix(deps): require numpy >=1.18.1
END_COMMIT_OVERRIDE

- Bump  `packaging` to `>= 22.0` to resolve the error in [this build log](https://github.com/googleapis/python-bigquery-pandas/actions/runs/10907179762/job/30270206277)
```
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```
- Bump `google-cloud-bigquery` to `>=3.4.2` to resolve the error [this build log](https://github.com/googleapis/python-bigquery-pandas/actions/runs/10907184593/job/30270221621) 
```
google-cloud-bigquery 3.3.5 depends on packaging<22.0.0dev and >=14.3
```
- Bump `numpy` to `>=1.18.1` to resolve the error in [this build log](https://github.com/googleapis/python-bigquery-pandas/actions/runs/10907250964/job/30270457452)
```
ModuleNotFoundError: No module named 'distutils.msvccompiler'
```
