### PR TITLE
chore: adds Python 3.7/3.8 EOL pending deprecation warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -208,6 +208,7 @@ def default(session):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
         "--cov=pandas_gbq",
         "--cov=tests/unit",
@@ -290,6 +291,7 @@ def system(session):
         session.run(
             "py.test",
             "--quiet",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
             *session.posargs,
@@ -298,6 +300,7 @@ def system(session):
         session.run(
             "py.test",
             "--quiet",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,
             *session.posargs,
@@ -372,6 +375,7 @@ def prerelease(session):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         f"--junitxml=prerelease_unit_{session.python}_sponge_log.xml",
         os.path.join("tests", "unit"),
         *session.posargs,
@@ -380,6 +384,7 @@ def prerelease(session):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         f"--junitxml=prerelease_system_{session.python}_sponge_log.xml",
         os.path.join("tests", "system"),
         *session.posargs,

--- a/pandas_gbq/__init__.py
+++ b/pandas_gbq/__init__.py
@@ -6,6 +6,19 @@ from pandas_gbq import version as pandas_gbq_version
 
 from .gbq import Context, context, read_gbq, to_gbq  # noqa
 
+from . import _versions_helpers
+
+sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()
+if sys_major == 3 and sys_minor in (7, 8):
+    warnings.warn(
+        "The python-bigquery library will stop supporting Python 3.7 "
+        "and Python 3.8 in a future major release expected in Q4 2024. "
+        f"Your Python version is {sys_major}.{sys_minor}.{sys_micro}. We "
+        "recommend that you update soon to ensure ongoing support. For "
+        "more details, see: [Google Cloud Client Libraries Supported Python Versions policy](https://cloud.google.com/python/docs/supported-python-versions)",
+        PendingDeprecationWarning,
+    )
+
 __version__ = pandas_gbq_version.__version__
 
 __all__ = [

--- a/pandas_gbq/__init__.py
+++ b/pandas_gbq/__init__.py
@@ -4,9 +4,8 @@
 
 from pandas_gbq import version as pandas_gbq_version
 
-from .gbq import Context, context, read_gbq, to_gbq  # noqa
-
 from . import _versions_helpers
+from .gbq import Context, context, read_gbq, to_gbq  # noqa
 
 sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()
 if sys_major == 3 and sys_minor in (7, 8):

--- a/pandas_gbq/__init__.py
+++ b/pandas_gbq/__init__.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import warnings
+
 from pandas_gbq import version as pandas_gbq_version
 
 from . import _versions_helpers

--- a/pandas_gbq/_versions_helpers.py
+++ b/pandas_gbq/_versions_helpers.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helper functions for verifying versions of installed modules."""
+
+
+import sys
+from typing import Tuple
+
+
+def extract_runtime_version() -> Tuple[int, int, int]:
+    # Retrieve the version information
+    version_info = sys.version_info
+
+    # Extract the major, minor, and micro components
+    major = version_info.major
+    minor = version_info.minor
+    micro = version_info.micro
+
+    # Display the version number in a clear format
+    return major, minor, micro


### PR DESCRIPTION
Adds a `PendingDeprecationWarning` and additional code logic to output that warning if the user attempts to install the repo using Python 3.7 or 3.8.

The expected outcome is that the system will display a PendingDeprecationWarning if it detects Python runtimes 3.7 or 3.8, and will display nothing if using more recent Python runtimes 3.9 to 3.x.