### PR TITLE
test: update minimum pandas requirement for testing purposes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependencies = [
     "setuptools",
     "db-dtypes >=1.0.4,<2.0.0",
     "numpy >=1.18.1",
-    "pandas >=1.1.4",
+    "pandas >=2.0",
     "pyarrow >=4.0.0",
     "pydata-google-auth >=1.5.0",
     # Note: google-api-core and google-auth are also included via transitive

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -14,7 +14,7 @@ google-auth-oauthlib==0.7.0
 google-cloud-bigquery==3.4.2
 google-cloud-bigquery-storage==2.16.2
 numpy==1.18.1
-pandas==1.1.4
+#pandas==1.1.4
 pyarrow==4.0.0
 pydata-google-auth==1.5.0
 Shapely==1.8.4

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,2 +1,2 @@
 numpy==1.19.4
-pandas==1.1.4
+#pandas==1.1.4


### PR DESCRIPTION
This is a WIP for testing purposes only.
Trying to see what happens when we constrain the library to only using `pandas 2.0` or above.

DO NOT MERGE.