### PR TITLE
chore: update staging bucket to dev

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -30,9 +30,9 @@ env_vars: {
 
 env_vars: {
     key: "V2_STAGING_BUCKET"
-    # Push non-cloud library docs to `docs-staging-v2-staging` instead of the
+    # Push non-cloud library docs to `docs-staging-v2-dev` instead of the
     # Cloud RAD bucket `docs-staging-v2`
-    value: "docs-staging-v2-staging"
+    value: "docs-staging-v2-dev"
 }
 
 # It will upload the docker image after successful builds.


### PR DESCRIPTION
The staging bucket is no longer used (b/374954111). Changing to dev instead.

Towards b/374991608 🦕
