### PR TITLE
fix: ensure BIGNUMERIC type is used if scale > 9 in Decimal values

### DIFF
--- a/pandas_gbq/schema/pyarrow_to_bigquery.py
+++ b/pandas_gbq/schema/pyarrow_to_bigquery.py
@@ -72,6 +72,13 @@ def arrow_type_to_bigquery_field(
             return schema.SchemaField(name, "TIMESTAMP")
 
     detected_type = _ARROW_SCALAR_IDS_TO_BQ.get(type_.id, None)
+
+    # We need a special case for values that might fit in Arrow decimal128 but
+    # not with the scale/precision that is used in BigQuery's NUMERIC type.
+    # See: https://github.com/googleapis/python-bigquery/issues/1650
+    if detected_type == "NUMERIC" and type_.scale > 9:
+        detected_type = "BIGNUMERIC"
+
     if detected_type is not None:
         return schema.SchemaField(name, detected_type)
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Ensures fix for https://github.com/googleapis/python-bigquery/issues/1650 makes its way to pandas-gbq as well.
Unblocks https://github.com/googleapis/python-bigquery/pull/2095
🦕
