### PR TITLE
build: use python 3.10 for testing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black==23.7.0"
 ISORT_VERSION = "isort==5.10.1"
 LINT_PATHS = ["docs", "pandas_gbq", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 
 UNIT_TEST_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/owlbot.py
+++ b/owlbot.py
@@ -34,6 +34,7 @@ extras_by_python = {
 }
 extras = ["tqdm", "geopandas"]
 templated_files = common.py_library(
+    default_python_version="3.10",
     unit_test_python_versions=["3.8", "3.9", "3.10", "3.11", "3.12"],
     system_test_python_versions=["3.8", "3.9", "3.10", "3.11", "3.12"],
     cov_level=96,


### PR DESCRIPTION
This should resolve the following issue in the `prerelease` nox session

```
ERROR: Package 'google-cloud-bigquery' requires a different Python: 3.8.20 not in '>=3.9'
nox > Session prerelease failed.
```