### PR TITLE
fix: remove unnecessary global variable definition

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -271,7 +271,6 @@ class GbqConnector(object):
         rfc9110_delimiter=False,
         bigquery_client=None,
     ):
-        global context
         from google.api_core.exceptions import ClientError, GoogleAPIError
 
         from pandas_gbq import auth
@@ -869,8 +868,6 @@ def read_gbq(
     df: DataFrame
         DataFrame representing results of query.
     """
-    global context
-
     if dialect is None:
         dialect = context.dialect
 


### PR DESCRIPTION
A new rule in flake8 ([F824](https://github.com/PyCQA/flake8/commit/ce3411118382d9332feb2749c8f417d10bfa2584)) has caused our lint test to fail with the following error message, because we defined a global variable in some methods, but we didn't assign any value to them. In this case, you can access the global variable directly so it's unnecessary to define it.

```
nox > flake8 pandas_gbq tests
pandas_gbq/gbq.py:274:9: F824 `global context` is unused: name is never assigned in scope
pandas_gbq/gbq.py:872:5: F824 `global context` is unused: name is never assigned in scope
nox > Command flake8 pandas_gbq tests failed with exit code 1
```

Example log: https://github.com/googleapis/python-bigquery-pandas/actions/runs/14229816667/job/39877861461?pr=899

**Note:** We do change values of some fields to global `context`, but we do so by accessing its property, and `context` was not reassigned, so F824 still applies here. 