### PR TITLE
feat: [WIP] add dry_run option for read_gbq

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -116,6 +116,7 @@ def read_gbq(
     *,
     col_order=None,
     bigquery_client=None,
+    dry_run=False,
 ):
     r"""Read data from Google BigQuery to a pandas DataFrame.
 
@@ -266,6 +267,8 @@ def read_gbq(
     bigquery_client : google.cloud.bigquery.Client, optional
         A Google Cloud BigQuery Python Client instance. If provided, it will be used for reading
         data, while the project and credentials parameters will be ignored.
+    dry_run : bool, default False
+        If true, executes the query in dry run mode and returns a statistic report as a Pandas series.
 
     Returns
     -------
@@ -317,6 +320,19 @@ def read_gbq(
         client_secret=client_secret,
         bigquery_client=bigquery_client,
     )
+
+    if dry_run:
+        if not _is_query(query_or_table):
+            # If the input is a table reference, turn it to a query
+            query_or_table = f"SELECT * FROM `{query_or_table}`;"
+        return connector.run_query(
+            query_or_table,
+            configuration=configuration,
+            max_results=max_results,
+            progress_bar_type=progress_bar_type,
+            dtypes=dtypes,
+            dry_run=True,
+        )
 
     if _is_query(query_or_table):
         final_df = connector.run_query(

--- a/pandas_gbq/gbq_connector.py
+++ b/pandas_gbq/gbq_connector.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional, Sequence, Union
 import warnings
 
 import numpy as np
-import pandas
 
 # Only import at module-level at type checking time to avoid circular
 # dependencies in the pandas package, which has an optional dependency on
@@ -280,7 +279,7 @@ class GbqConnector:
     def _report_dry_run_stats(
         self,
         query_job,
-    ) -> pandas.Series:
+    ) -> "pandas.Series":
         job_api_repr = copy.deepcopy(query_job._properties)
 
         index = []
@@ -306,6 +305,8 @@ class GbqConnector:
         ):
             index.append(key)
             values.append(query_stats.get(key))
+
+        import pandas
 
         index.append("creationTime")
         values.append(

--- a/tests/system/test_read_gbq.py
+++ b/tests/system/test_read_gbq.py
@@ -672,3 +672,48 @@ def test_read_gbq_with_bq_client(read_gbq_with_bq_client):
         {"numbers": pandas.Series([1, 2, 3], dtype="Int64")}
     )
     pandas.testing.assert_frame_equal(actual_result, expected_result)
+
+
+def test_read_gbq_table_dry_run(read_gbq, writable_table):
+    result = read_gbq(writable_table, dry_run=True)
+
+    assert isinstance(result, pandas.Series)
+    pandas.testing.assert_index_equal(
+        result.index,
+        pandas.Index(
+            [
+                "fieldCount",
+                "fields",
+                "destinationTable",
+                "useLegacySql",
+                "referencedTables",
+                "totalBytesProcessed",
+                "cacheHit",
+                "statementType",
+                "creationTime",
+            ]
+        ),
+    )
+
+
+def test_read_gbq_query_dry_run(read_gbq, writable_table):
+    query = f"SELECT * FROM {writable_table} LIMIT 10"
+    result = read_gbq(query, dry_run=True)
+
+    assert isinstance(result, pandas.Series)
+    pandas.testing.assert_index_equal(
+        result.index,
+        pandas.Index(
+            [
+                "fieldCount",
+                "fields",
+                "destinationTable",
+                "useLegacySql",
+                "referencedTables",
+                "totalBytesProcessed",
+                "cacheHit",
+                "statementType",
+                "creationTime",
+            ]
+        ),
+    )

--- a/tests/unit/test_gbq.py
+++ b/tests/unit/test_gbq.py
@@ -92,7 +92,7 @@ def default_bigquery_client(mock_bigquery_client, mock_query_job, mock_row_itera
 
 
 @pytest.fixture(autouse=True)
-def dryrun_bigquery_client(mock_bigquery_client, mock_query_job, mock_row_iterator):
+def dryrun_bigquery_client(mock_bigquery_client, mock_query_job):
     mock_query_job._properties = {
         "configuration": {
             "query": {


### PR DESCRIPTION
The basic logic is:
* If the input is a query, dry run it
* If the input is a table reference, convert it to a SQL (`"SELECT * FROM ..."`) and dry run it.

The dry run stats are returned in a Pandas Series, similar with https://github.com/googleapis/python-bigquery-dataframes/blob/30a62372b2fd72deaf7dbc1dbce8b48f03b3041c/bigframes/core/blocks.py#L818-L885

I didn't perform the type conversion from BQ schema to Pandas dtypes due to non-trivial efforts. We could either:
* Re-use BQ Python client's conversion function, which is buried somewhere deep in the codebase, and is possibly not supposed to be invoked by external packages.
* Define our own conversion function, which needs to be kept in sync with the BQ client library.
