### PR TITLE
fix: remove pandas-gbq client ID for authentication

### DIFF
--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -13,20 +13,6 @@ CREDENTIALS_CACHE_DIRNAME = "pandas_gbq"
 CREDENTIALS_CACHE_FILENAME = "bigquery_credentials.dat"
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 
-# The following constants are used for end-user authentication.
-# It identifies (via credentials from the pandas-gbq-auth GCP project) the
-# application that is requesting permission to access the BigQuery API on
-# behalf of a G Suite or Gmail user.
-#
-# In a web application, the client secret would be kept secret, but this is not
-# possible for applications that are installed locally on an end-user's
-# machine.
-#
-# See: https://cloud.google.com/docs/authentication/end-user for details.
-CLIENT_ID = "725825577420-unm2gnkiprugilg743tkbig250f4sfsj.apps.googleusercontent.com"
-CLIENT_SECRET = "4hqze9yI8fxShls8eJWkeMdJ"
-
-
 def get_credentials(
     private_key=None,
     project_id=None,
@@ -46,12 +32,6 @@ google.oauth2.service_account.Credentials.from_service_account_file or
 google.oauth2.service_account.Credentials.from_service_account_info class
 method from the google-auth package."""
         )
-
-    if client_id is None:
-        client_id = CLIENT_ID
-
-    if client_secret is None:
-        client_secret = CLIENT_SECRET
 
     credentials, default_project_id = pydata_google_auth.default(
         SCOPES,

--- a/pandas_gbq/auth.py
+++ b/pandas_gbq/auth.py
@@ -13,6 +13,7 @@ CREDENTIALS_CACHE_DIRNAME = "pandas_gbq"
 CREDENTIALS_CACHE_FILENAME = "bigquery_credentials.dat"
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 
+
 def get_credentials(
     private_key=None,
     project_id=None,


### PR DESCRIPTION
pandas-gbq's client ID has been failing for some time due to `Error 400: redirect_uri_mismatch`. Since it's only used for a fallback if no application default credentials are available, it's probably OK to use pydata-google-auth's client ID instead.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
