### PR TITLE
chore: librarian release pull request: 20251117T201128Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: pandas-gbq
-    version: 0.30.0
+    version: 0.31.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
-## [0.31.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.30.0...pandas-gbq-v0.31.0) (2025-11-17)
+## [0.31.0](https://github.com/googleapis/google-cloud-python/compare/v0.30.0...v0.31.0) (2025-11-17)
 
 
 ### Features
 
-* add pandas_gbq.sample (#983) ([ac771c12f58b7378a8550515c9c656da7fa980a8](https://github.com/googleapis/google-cloud-python/commit/ac771c12f58b7378a8550515c9c656da7fa980a8))
+* add pandas_gbq.sample (#983) ([ac771c12f58b7378a8550515c9c656da7fa980a8](https://github.com/googleapis/python-bigquery-pandas/commit/ac771c12f58b7378a8550515c9c656da7fa980a8))
 
 ## [0.30.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.29.2...v0.30.0) (2025-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
-## [0.31.0](https://github.com/googleapis/google-cloud-python/compare/v0.30.0...v0.31.0) (2025-11-17)
+## [0.31.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.30.0...v0.31.0) (2025-11-17)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
+## [0.31.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.30.0...pandas-gbq-v0.31.0) (2025-11-17)
+
+
+### Features
+
+* add pandas_gbq.sample (#983) ([ac771c12f58b7378a8550515c9c656da7fa980a8](https://github.com/googleapis/google-cloud-python/commit/ac771c12f58b7378a8550515c9c656da7fa980a8))
+
 ## [0.30.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.29.2...v0.30.0) (2025-10-31)
 
 

--- a/pandas_gbq/version.py
+++ b/pandas_gbq/version.py
@@ -2,4 +2,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.6.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>pandas-gbq: 0.31.0</summary>

## [0.31.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.30.0...v0.31.0) (2025-11-17)

### Features

* add pandas_gbq.sample (#983) ([ac771c12](https://github.com/googleapis/python-bigquery-pandas/commit/ac771c12))

</details>