### PR TITLE
chore: librarian release pull request: 20251215T190656Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: pandas-gbq
-    version: 0.31.1
+    version: 0.32.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
+## [0.32.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.31.1...pandas-gbq-v0.32.0) (2025-12-16)
+
+
+### Features
+
+* Add support for Python 3.14 (#976) ([89b008d81e5992966ccab675511bc944682d0549](https://github.com/googleapis/google-cloud-python/commit/89b008d81e5992966ccab675511bc944682d0549))
+
+
+### Bug Fixes
+
+* boolean round-trip test and CSV datetime loading errors (#1000) ([d4431030e1b537e12f850d8206741b62ff4d7d67](https://github.com/googleapis/google-cloud-python/commit/d4431030e1b537e12f850d8206741b62ff4d7d67))
+
 ## [0.31.1](https://github.com/googleapis/python-bigquery-pandas/compare/v0.31.0...v0.31.1) (2025-12-08)
 
 ### Dependencies

--- a/pandas_gbq/version.py
+++ b/pandas_gbq/version.py
@@ -2,4 +2,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-__version__ = "0.31.1"
+__version__ = "0.32.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>pandas-gbq: 0.32.0</summary>

## [0.32.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.31.1...v0.32.0) (2025-12-15)

### Features

* Add support for Python 3.14 (#976) ([89b008d8](https://github.com/googleapis/python-bigquery-pandas/commit/89b008d8))

### Bug Fixes

* boolean round-trip test and CSV datetime loading errors (#1000) ([d4431030](https://github.com/googleapis/python-bigquery-pandas/commit/d4431030))

</details>