### PR TITLE
chore: librarian release pull request: 20260105T185010Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: pandas-gbq
-    version: 0.32.0
+    version: 0.33.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
-## [0.33.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.32.0...pandas-gbq-v0.33.0) (2026-01-05)
+## [0.33.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.32.0...v0.33.0) (2026-01-05)
 
 
 ### Features
 
-* add dry run to the read_gbq function (#979) ([516f986f6935c9a6426e6a9b1702cb2002916362](https://github.com/googleapis/google-cloud-python/commit/516f986f6935c9a6426e6a9b1702cb2002916362))
+* add dry run to the read_gbq function (#979) ([516f986f6935c9a6426e6a9b1702cb2002916362](https://github.com/googleapis/python-bigquery-pandas/commit/516f986f6935c9a6426e6a9b1702cb2002916362))
 
 ## [0.32.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.31.1...pandas-gbq-v0.32.0) (2025-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/pandas-gbq/#history
 
+## [0.33.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.32.0...pandas-gbq-v0.33.0) (2026-01-05)
+
+
+### Features
+
+* add dry run to the read_gbq function (#979) ([516f986f6935c9a6426e6a9b1702cb2002916362](https://github.com/googleapis/google-cloud-python/commit/516f986f6935c9a6426e6a9b1702cb2002916362))
+
 ## [0.32.0](https://github.com/googleapis/google-cloud-python/compare/pandas-gbq-v0.31.1...pandas-gbq-v0.32.0) (2025-12-16)
 
 

--- a/pandas_gbq/version.py
+++ b/pandas_gbq/version.py
@@ -2,4 +2,4 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>pandas-gbq: 0.33.0</summary>

## [0.33.0](https://github.com/googleapis/python-bigquery-pandas/compare/v0.32.0...v0.33.0) (2026-01-05)

### Features

* add dry run to the read_gbq function (#979) ([516f986f](https://github.com/googleapis/python-bigquery-pandas/commit/516f986f))

</details>